### PR TITLE
feat: add backend ip lookup service

### DIFF
--- a/apps/backend/app/__init__.py
+++ b/apps/backend/app/__init__.py
@@ -1,0 +1,2 @@
+# marks package
+

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import List, Optional
+from urllib.parse import urlparse
+
+from pydantic import Field, ValidationError
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+# Always resolve .env inside apps/backend
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+ENV_PATH = BACKEND_DIR / ".env"
+
+
+def origin_of(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    p = urlparse(url)
+    if p.scheme and p.netloc:
+        return f"{p.scheme}://{p.netloc}"
+    return None
+
+
+class Settings(BaseSettings):
+    """
+    Configuration is 100% environment-driven.
+    No defaults — missing required vars cause startup failure.
+    """
+
+    # --- REQUIRED ---
+    DATASTORE_PROVIDER: str = Field(..., description="Datastore provider, e.g. 'csv'")
+    DATA_FILE_PATH: str = Field(..., description="Path to ip,city,country data file")
+
+    # --- OPTIONAL ---
+    LOG_LEVEL: Optional[str] = None
+    FRONTEND_BASE_URL: Optional[str] = None
+    ALLOWED_ORIGINS: Optional[List[str]] = None
+    DEV_INCLUDE_LOCALHOST: bool = False
+
+    model_config = SettingsConfigDict(
+        env_file=str(ENV_PATH),
+        env_nested_delimiter="__",
+        extra="ignore",
+    )
+
+    @property
+    def computed_allowed_origins(self) -> List[str]:
+        out: List[str] = []
+
+        if self.ALLOWED_ORIGINS:
+            out.extend(self.ALLOWED_ORIGINS)
+
+        fe_origin = origin_of(self.FRONTEND_BASE_URL)
+        if fe_origin and fe_origin not in out:
+            out.append(fe_origin)
+
+        if self.DEV_INCLUDE_LOCALHOST:
+            for local in ("http://localhost:5173", "http://127.0.0.1:5173"):
+                if local not in out:
+                    out.append(local)
+
+        return out
+
+
+try:
+    settings = Settings()
+except ValidationError as e:
+    raise RuntimeError(
+        f"[config] Missing/invalid environment configuration. "
+        f"Check apps/backend/.env. Details:\n{e}"
+    )
+

--- a/apps/backend/app/datastore/__init__.py
+++ b/apps/backend/app/datastore/__init__.py
@@ -1,0 +1,2 @@
+# mark package
+

--- a/apps/backend/app/datastore/base.py
+++ b/apps/backend/app/datastore/base.py
@@ -1,0 +1,8 @@
+from typing import Protocol, Optional
+
+class IpLocator(Protocol):
+    def lookup(self, ip: str) -> Optional[tuple[str, str]]:
+        ...
+    def suggest(self, prefix: str, limit: int = 10) -> list[str]:
+        ...
+

--- a/apps/backend/app/datastore/csv_provider.py
+++ b/apps/backend/app/datastore/csv_provider.py
@@ -1,0 +1,41 @@
+import csv
+import ipaddress
+import bisect
+from typing import Optional
+
+class CsvIpLocator:
+    def __init__(self, path: str):
+        self._map: dict[str, tuple[str, str]] = {}
+        self._sorted_ips: list[str] = []
+        self._load(path)
+
+    @staticmethod
+    def _valid_ipv4(s: str) -> bool:
+        try:
+            ipaddress.IPv4Address(s)
+            return True
+        except Exception:
+            return False
+
+    def _load(self, path: str) -> None:
+        with open(path, newline="", encoding="utf-8") as f:
+            reader = csv.reader(f)
+            for row in reader:
+                if len(row) < 3:
+                    continue
+                ip, city, country = row[0].strip(), row[1].strip(), row[2].strip()
+                if not self._valid_ipv4(ip):
+                    continue
+                self._map[ip] = (country, city)
+        self._sorted_ips = sorted(self._map.keys())
+
+    def lookup(self, ip: str) -> Optional[tuple[str, str]]:
+        return self._map.get(ip)
+
+    def suggest(self, prefix: str, limit: int = 10) -> list[str]:
+        if not prefix:
+            return []
+        lo = bisect.bisect_left(self._sorted_ips, prefix)
+        hi = bisect.bisect_right(self._sorted_ips, prefix + "\uffff")
+        return self._sorted_ips[lo:hi][:max(1, min(limit, 50))]
+

--- a/apps/backend/app/datastore/factory.py
+++ b/apps/backend/app/datastore/factory.py
@@ -1,0 +1,8 @@
+from .csv_provider import CsvIpLocator
+
+def build_locator(provider: str, data_path: str):
+    provider = (provider or "").lower()
+    if provider == "csv":
+        return CsvIpLocator(data_path)
+    raise ValueError(f"Unsupported DATASTORE_PROVIDER='{provider}'")
+

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -1,0 +1,62 @@
+import logging
+import re
+import ipaddress
+from fastapi import FastAPI, Query, Response
+from fastapi.middleware.cors import CORSMiddleware
+from .config import settings
+from .models import LocationResponse, ErrorResponse, SuggestResponse
+from .datastore.factory import build_locator
+
+log = logging.getLogger("uvicorn")
+if settings.LOG_LEVEL:
+    logging.getLogger().setLevel(settings.LOG_LEVEL)
+
+app = FastAPI(title="IP → Country Service", version="1.0.0")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=settings.computed_allowed_origins,
+    allow_credentials=False,
+    allow_methods=["GET"],
+    allow_headers=["*"],
+)
+
+LOCATOR = build_locator(settings.DATASTORE_PROVIDER, settings.DATA_FILE_PATH)
+
+def _is_ipv4(s: str) -> bool:
+    try:
+        ipaddress.IPv4Address(s)
+        return True
+    except Exception:
+        return False
+
+_PREFIX_RE = re.compile(r"^[0-9.]{1,15}$")
+
+@app.get("/healthz")
+def healthz():
+    return {"status": "ok"}
+
+@app.get(
+    "/v1/find-country",
+    responses={400: {"model": ErrorResponse}, 404: {"model": ErrorResponse}, 500: {"model": ErrorResponse}},
+)
+def find_country(ip: str = Query(..., description="IPv4 address")):
+    if not _is_ipv4(ip):
+        return Response(ErrorResponse(error="invalid IP").model_dump_json(), status_code=400, media_type="application/json")
+    res = LOCATOR.lookup(ip)
+    if not res:
+        return Response(ErrorResponse(error="not found").model_dump_json(), status_code=404, media_type="application/json")
+    country, city = res
+    return LocationResponse(country=country, city=city)
+
+@app.get(
+    "/v1/suggest",
+    response_model=SuggestResponse,
+    responses={400: {"model": ErrorResponse}, 500: {"model": ErrorResponse}},
+)
+def suggest(prefix: str = Query(..., min_length=1, max_length=15), limit: int = Query(10, ge=1, le=50)):
+    if not _PREFIX_RE.match(prefix):
+        return Response(ErrorResponse(error="invalid prefix").model_dump_json(), status_code=400, media_type="application/json")
+    suggestions = LOCATOR.suggest(prefix, limit)
+    return SuggestResponse(suggestions=suggestions)
+

--- a/apps/backend/app/models.py
+++ b/apps/backend/app/models.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+class LocationResponse(BaseModel):
+    country: str
+    city: str
+
+class ErrorResponse(BaseModel):
+    error: str
+
+class SuggestResponse(BaseModel):
+    suggestions: list[str]
+

--- a/apps/backend/requirements.txt
+++ b/apps/backend/requirements.txt
@@ -1,4 +1,6 @@
-fastapi
-uvicorn
-pydantic-settings
-pytest
+fastapi==0.115.0
+uvicorn[standard]==0.30.6
+pydantic==2.9.1
+pydantic-settings==2.4.0
+python-dotenv==1.0.1
+


### PR DESCRIPTION
## Summary
- add FastAPI backend with environment-driven configuration and CSV datastore
- implement IP lookup and suggestion endpoints
- define backend dependencies

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8deb57208832ea92ba488f97531b6