### PR TITLE
Add backend Dockerfile and Render service config

### DIFF
--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -1,0 +1,18 @@
+# ---- builder ----
+FROM python:3.12-slim AS builder
+WORKDIR /app
+COPY apps/backend/requirements.txt .
+RUN pip install --upgrade pip && pip wheel --wheel-dir=/wheels -r requirements.txt
+
+# ---- runtime ----
+FROM python:3.12-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY --from=builder /wheels /wheels
+RUN pip install --no-index --find-links=/wheels /wheels/*
+
+COPY apps/backend/app /app/app
+COPY data /app/data
+
+EXPOSE 8080
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/infra/render.yaml
+++ b/infra/render.yaml
@@ -1,6 +1,22 @@
 services:
   - type: web
-    name: ip-country-backend
-    env: python
-    buildCommand: pip install -r apps/backend/requirements.txt
-    startCommand: uvicorn app.main:app --host 0.0.0.0 --port 8080
+    name: ip2country-backend
+    env: docker
+    plan: free
+    healthCheckPath: /healthz
+    envVars:
+      - key: DATASTORE_PROVIDER
+        value: csv
+      - key: DATA_FILE_PATH
+        value: /app/data/sample.csv
+      - key: LOG_LEVEL
+        value: INFO
+      # Derives CORS origin from this URL's origin
+      - key: FRONTEND_BASE_URL
+        value: https://<your-gh-username>.github.io/<your-repo>
+      # Optional JSON list of extra origins
+      # - key: ALLOWED_ORIGINS
+      #   value: '["https://example.com"]'
+      # Allow vite localhost origins during dev if you expose the container
+      - key: DEV_INCLUDE_LOCALHOST
+        value: "false"


### PR DESCRIPTION
## Summary
- containerize backend with a Python 3.12 Dockerfile exposing 8080
- define Render service with environment configuration

## Testing
- `pytest` *(fails: No module named 'httpx'; attempted `pip install httpx` but network is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e33fed64832eb425d9c22894e7e9