### PR TITLE
feat: add Torq-inspired Vue frontend

### DIFF
--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,9 +1,10 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>IP to Country</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <title>IP → Country</title>
+    <meta name="color-scheme" content="dark">
   </head>
   <body>
     <div id="app"></div>

--- a/apps/frontend/src/App.vue
+++ b/apps/frontend/src/App.vue
@@ -1,10 +1,24 @@
-<template>
-  <div>
-    <h1>IP to Country</h1>
-    <IpSearch />
-  </div>
-</template>
-
 <script setup>
 import IpSearch from './components/IpSearch.vue'
+const apiBase = import.meta.env.VITE_API_BASE_URL || ''
+const missingApi = !apiBase
 </script>
+
+<template>
+  <div class="container">
+    <div class="glass">
+      <div class="h1">IP → Country</div>
+      <div class="subtitle">
+        Type an IPv4 address. We’ll look up its <b>country</b> and <b>city</b>.
+      </div>
+
+      <div v-if="missingApi" class="banner">
+        <b>Heads up:</b> VITE_API_BASE_URL is not set. Create <code>apps/frontend/.env.local</code>
+        with <code>VITE_API_BASE_URL=http://localhost:8080</code> (or your Render URL) and rebuild.
+      </div>
+
+      <IpSearch />
+      <div class="footer">UI palette inspired by Torq (accent #85C4FF)</div>
+    </div>
+  </div>
+</template>

--- a/apps/frontend/src/assets/styles.css
+++ b/apps/frontend/src/assets/styles.css
@@ -1,5 +1,73 @@
-body {
-  font-family: sans-serif;
-  margin: 0;
-  padding: 0;
+:root{
+  --torq-accent: #85C4FF;
+  --bg-900: #0b0f19;
+  --bg-800: #111827;
+  --text-100: #f3f4f6;
+  --text-300: #d1d5db;
+  --muted: #6b7280;
+  --card: #0e1625;
+  --card-2: #121b2e;
+  --focus: rgba(133,196,255,.35);
+  --danger: #ff4b4b;
 }
+* { box-sizing: border-box; }
+html, body, #app {
+  margin: 0; padding: 0; height: 100%;
+  background: radial-gradient(1200px 800px at 10% 10%, #0d1222 0%, #0b0f19 60%, #0a0d16 100%);
+  color: var(--text-100);
+  font-family: ui-sans-serif, system-ui, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
+}
+.container { max-width: 720px; margin: 8vh auto; padding: 24px; }
+.glass {
+  background: linear-gradient(180deg, rgba(255,255,255,.06), rgba(255,255,255,.02));
+  border: 1px solid rgba(255,255,255,.08);
+  box-shadow: 0 10px 30px rgba(0,0,0,.35), inset 0 1px 0 rgba(255,255,255,.04);
+  border-radius: 16px; padding: 24px;
+}
+.h1 { font-size: 24px; font-weight: 700; letter-spacing: .2px; }
+.subtitle { color: var(--text-300); margin-top: 6px; line-height: 1.35; }
+.banner {
+  margin-top: 12px;
+  background: rgba(255, 196, 0, .08);
+  border: 1px solid rgba(255,196,0,.25);
+  color: #ffe9a6;
+  border-radius: 12px; padding: 10px 12px; font-size: 13px;
+}
+.form { margin-top: 18px; }
+.input-wrap { position: relative; }
+.input {
+  width: 100%; background: var(--card); color: var(--text-100);
+  border: 1px solid rgba(255,255,255,.1); border-radius: 14px;
+  padding: 14px 16px; outline: none; transition: border .15s, box-shadow .15s, background .2s;
+}
+.input:focus { border-color: var(--torq-accent); box-shadow: 0 0 0 4px var(--focus); }
+.btn {
+  margin-top: 12px; width: 100%;
+  background: linear-gradient(180deg, var(--torq-accent), #5eaef4);
+  color: #0b0f19; border: none; border-radius: 14px; padding: 12px 16px;
+  font-weight: 700; cursor: pointer; transition: transform .06s ease, filter .2s; user-select: none;
+}
+.btn[disabled] { opacity: .6; cursor: not-allowed; }
+.btn:hover:not([disabled]) { filter: brightness(1.05); }
+.btn:active:not([disabled]) { transform: translateY(1px); }
+.suggestions {
+  position: absolute; left: 0; right: 0; top: calc(100% + 6px);
+  background: var(--card-2); border: 1px solid rgba(255,255,255,.08);
+  border-radius: 12px; overflow: hidden; box-shadow: 0 16px 40px rgba(0,0,0,.5);
+  z-index: 10; max-height: 280px; overflow-y: auto;
+}
+.sugg-item {
+  padding: 10px 14px; cursor: pointer; color: var(--text-300);
+  display: flex; align-items: center; gap: 8px;
+}
+.sugg-item:hover, .sugg-item[aria-selected="true"] {
+  background: rgba(133,196,255,.08); color: var(--text-100);
+}
+.result, .error {
+  margin-top: 16px; padding: 14px 16px; border-radius: 12px;
+  border: 1px solid rgba(255,255,255,.08);
+}
+.result { background: rgba(133,196,255,.06); }
+.error  { background: rgba(255, 75, 75, .07); border-color: rgba(255, 75, 75, .25); color: #ffb3b3; }
+.helper { margin-top: 10px; color: var(--muted); font-size: 12px; }
+.footer { margin-top: 18px; color: var(--muted); font-size: 12px; text-align: center; }

--- a/apps/frontend/src/components/IpSearch.vue
+++ b/apps/frontend/src/components/IpSearch.vue
@@ -1,18 +1,217 @@
-<template>
-  <div>
-    <input v-model="ip" placeholder="Enter IP" />
-    <button @click="search">Search</button>
-    <p v-if="country">Country: {{ country }}</p>
-  </div>
-</template>
-
 <script setup>
-import { ref } from 'vue'
+import { ref, computed, onMounted, onBeforeUnmount, nextTick } from 'vue'
+
+const API_BASE = (import.meta.env.VITE_API_BASE_URL || '').trim()
+
+function makeUrl(path, params = {}) {
+  // Robust URL builder that tolerates trailing/leading slashes
+  const base = API_BASE.replace(/\/+$/,'')
+  const p = path.startsWith('/') ? path : `/${path}`
+  const url = new URL(base + p)
+  Object.entries(params).forEach(([k,v]) => url.searchParams.set(k, String(v)))
+  return url
+}
 
 const ip = ref('')
-const country = ref('')
+const loading = ref(false)
+const errorMsg = ref('')
+const result = ref(null)
 
-function search() {
-  country.value = 'Unknown'
+const open = ref(false)
+const suggestions = ref([])
+const highlighted = ref(-1)
+let abortCtrl = null
+let debounceTimer = null
+let suggestTimeout = null
+
+const inputEl = ref(null)
+const listboxId = 'ip-suggestions'
+const activeDesc = computed(() => (highlighted.value >= 0 ? `opt-${highlighted.value}` : undefined))
+
+const ipRegex = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/
+const partialRegex = /^[0-9.]{1,15}$/
+const valid = computed(() => ipRegex.test(ip.value))
+
+function setError(msg) {
+  errorMsg.value = msg
+  result.value = null
 }
+
+async function fetchSuggest(prefix) {
+  if (!partialRegex.test(prefix) || prefix.length < 2 || !API_BASE) {
+    suggestions.value = []
+    open.value = false
+    return
+  }
+  if (abortCtrl) abortCtrl.abort()
+  abortCtrl = new AbortController()
+
+  // add a safety timeout to avoid dangling requests
+  clearTimeout(suggestTimeout)
+  suggestTimeout = setTimeout(() => abortCtrl?.abort(), 6000)
+
+  try {
+    const url = makeUrl('/v1/suggest', { prefix, limit: 10 })
+    const r = await fetch(url, { signal: abortCtrl.signal, headers: { 'Accept': 'application/json' } })
+    if (!r.ok) throw new Error('suggest failed')
+    const data = await r.json()
+    suggestions.value = Array.isArray(data?.suggestions) ? data.suggestions : []
+    open.value = suggestions.value.length > 0
+    highlighted.value = -1
+    await nextTick()
+  } catch {
+    // non-blocking UX: ignore suggest failures
+    open.value = false
+  } finally {
+    clearTimeout(suggestTimeout)
+  }
+}
+
+function onInput(e) {
+  const v = e.target.value.trim()
+  ip.value = v
+  setError('')
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => fetchSuggest(v), 280)
+}
+
+function onKeydown(e) {
+  if (e.key === 'Enter' && !open.value) {
+    // Enter submits when dropdown is closed
+    e.preventDefault()
+    submit()
+    return
+  }
+  if (!open.value || suggestions.value.length === 0) return
+  if (e.key === 'ArrowDown') {
+    e.preventDefault()
+    highlighted.value = (highlighted.value + 1) % suggestions.value.length
+  } else if (e.key === 'ArrowUp') {
+    e.preventDefault()
+    highlighted.value = (highlighted.value - 1 + suggestions.value.length) % suggestions.value.length
+  } else if (e.key === 'Enter') {
+    e.preventDefault()
+    if (highlighted.value >= 0) {
+      ip.value = suggestions.value[highlighted.value]
+      open.value = false
+    }
+  } else if (e.key === 'Escape') {
+    open.value = false
+  } else if (e.key === 'Tab') {
+    open.value = false
+  }
+}
+
+function pick(s) {
+  ip.value = s
+  open.value = false
+  inputEl.value?.focus()
+}
+
+async function submit() {
+  open.value = false
+  if (!API_BASE) {
+    setError('API base is not configured (VITE_API_BASE_URL).')
+    return
+  }
+  if (!valid.value) {
+    setError('invalid IP')
+    return
+  }
+  loading.value = true
+  setError('')
+  result.value = null
+  try {
+    const url = makeUrl('/v1/find-country', { ip: ip.value })
+    const r = await fetch(url, { headers: { 'Accept': 'application/json' } })
+    const data = await r.json()
+    if (!r.ok) {
+      setError(data?.error || 'internal error')
+    } else {
+      result.value = data
+    }
+  } catch {
+    setError('internal error')
+  } finally {
+    loading.value = false
+  }
+}
+
+function onClickOutside(e) {
+  const root = document.getElementById('ip-search-root')
+  if (root && !root.contains(e.target)) open.value = false
+}
+
+onMounted(() => document.addEventListener('click', onClickOutside))
+onBeforeUnmount(() => {
+  document.removeEventListener('click', onClickOutside)
+  clearTimeout(debounceTimer)
+  clearTimeout(suggestTimeout)
+  if (abortCtrl) abortCtrl.abort()
+})
 </script>
+
+<template>
+  <form class="form" @submit.prevent="submit" novalidate>
+    <div id="ip-search-root">
+      <div class="input-wrap">
+        <input
+          ref="inputEl"
+          class="input"
+          type="text"
+          inputmode="numeric"
+          pattern="^([0-9]{1,3}\.){3}[0-9]{1,3}$"
+          autocomplete="off"
+          autocapitalize="off"
+          spellcheck="false"
+          placeholder="e.g., 2.22.233.255"
+          :aria-invalid="!valid && ip.length>0"
+          :aria-controls="listboxId"
+          role="combobox"
+          aria-autocomplete="list"
+          :aria-expanded="open"
+          :aria-activedescendant="activeDesc"
+          :value="ip"
+          @input="onInput"
+          @keydown="onKeydown"
+          @focus="() => suggestions.length && (open=true)"
+        />
+
+        <div
+          v-if="open"
+          class="suggestions"
+          role="listbox"
+          :id="listboxId"
+          aria-label="IP suggestions"
+        >
+          <div
+            v-for="(s, i) in suggestions"
+            :key="s"
+            class="sugg-item"
+            role="option"
+            :id="`opt-${i}`"
+            :aria-selected="i===highlighted"
+            @mousemove="highlighted=i"
+            @mousedown.prevent="pick(s)"
+          >
+            <span>🔎</span><span>{{ s }}</span>
+          </div>
+        </div>
+      </div>
+
+      <button class="btn" :disabled="loading || !valid" type="submit">
+        {{ loading ? 'Looking…' : 'Find' }}
+      </button>
+
+      <div v-if="result" class="result" role="status" aria-live="polite">
+        <div><b>Country:</b> {{ result.country }}</div>
+        <div><b>City:</b> {{ result.city }}</div>
+      </div>
+
+      <div v-if="errorMsg" class="error" role="alert">{{ errorMsg }}</div>
+      <div class="helper">
+        We only accept IPv4 (e.g., 8.8.8.8). Autocomplete offers known IPs from the active datastore.
+      </div>
+    </div>
+  </form>
+</template>

--- a/apps/frontend/vite.config.js
+++ b/apps/frontend/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
+// If deploying to GitHub Pages as a project site, update base to '/<repo>/'.
 export default defineConfig({
-  plugins: [vue()]
+  plugins: [vue()],
+  base: '/', // change to '/<repo>/' for Pages project site
 })


### PR DESCRIPTION
## Summary
- build Vue frontend with Torq-inspired styling and IP search
- add warning banner if API base is missing
- enhance IP search with debounced suggestions, ARIA combobox, and error handling

## Testing
- `pytest -q` *(fails: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68a8e4a24810832e9a9e21903d3571ee