### PR TITLE
Improve config path handling and add CI workflows

### DIFF
--- a/.github/workflows/backend-tests.yml
+++ b/.github/workflows/backend-tests.yml
@@ -1,0 +1,21 @@
+name: Backend Tests
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt pytest
+      - name: Run tests
+        env:
+          DATASTORE_PROVIDER: csv
+          DATA_FILE_PATH: data/sample.csv
+          DEV_INCLUDE_LOCALHOST: "true"
+        run: pytest -q
+

--- a/.github/workflows/frontend-build.yml
+++ b/.github/workflows/frontend-build.yml
@@ -1,0 +1,18 @@
+name: Frontend Build
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: apps/frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci || npm i
+      - run: npm run build
+        env:
+          VITE_BASE: /
+

--- a/apps/backend/Dockerfile
+++ b/apps/backend/Dockerfile
@@ -12,7 +12,7 @@ COPY --from=builder /wheels /wheels
 RUN pip install --no-index --find-links=/wheels /wheels/*
 
 COPY apps/backend/app /app/app
-COPY data /app/data
+COPY apps/backend/data /app/data
 
 EXPOSE 8080
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/apps/backend/app/config.py
+++ b/apps/backend/app/config.py
@@ -60,6 +60,16 @@ class Settings(BaseSettings):
 
         return out
 
+    @property
+    def data_file_path_abs(self) -> str:
+        """
+        Resolve DATA_FILE_PATH relative to apps/backend if not absolute.
+        """
+        p = Path(self.DATA_FILE_PATH)
+        if p.is_absolute():
+            return str(p)
+        return str((BACKEND_DIR / p).resolve())
+
 
 try:
     settings = Settings()

--- a/apps/backend/app/main.py
+++ b/apps/backend/app/main.py
@@ -21,7 +21,10 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-LOCATOR = build_locator(settings.DATASTORE_PROVIDER, settings.DATA_FILE_PATH)
+LOCATOR = build_locator(settings.DATASTORE_PROVIDER, settings.data_file_path_abs)
+
+log.info(f"[startup] CORS allow_origins={settings.computed_allowed_origins}")
+log.info(f"[startup] data_file_path_abs={settings.data_file_path_abs}")
 
 def _is_ipv4(s: str) -> bool:
     try:

--- a/apps/frontend/.env.local
+++ b/apps/frontend/.env.local
@@ -1,1 +1,0 @@
-VITE_API_BASE_URL=http://localhost:8080

--- a/apps/frontend/vite.config.js
+++ b/apps/frontend/vite.config.js
@@ -1,8 +1,7 @@
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
 
-// If deploying to GitHub Pages as a project site, update base to '/<repo>/'.
 export default defineConfig({
   plugins: [vue()],
-  base: '/', // change to '/<repo>/' for Pages project site
+  base: process.env.VITE_BASE || '/',
 })


### PR DESCRIPTION
## Summary
- resolve data file path relative to backend and log startup info
- copy correct data directory in backend Dockerfile
- allow Vite base override for GitHub Pages
- add backend tests and frontend build GitHub Actions
- drop tracked frontend `.env.local`

## Testing
- `python -m venv .venv && source .venv/bin/activate || . .venv/Scripts/activate`
- `pip install -r requirements.txt pytest` *(failed: Could not find a version that satisfies the requirement pytest / httpx module missing)*
- `pytest -q` *(failed: RuntimeError: httpx package missing)*
- `npm i` *(failed: Could not read package.json)*
- `npm run build` *(failed: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8ef261020832ea27be461f97420e1